### PR TITLE
fix: cross-platform simulate_key and game screenshot UI overlay capture

### DIFF
--- a/Editor/Commands/InputCommands.cs
+++ b/Editor/Commands/InputCommands.cs
@@ -1,14 +1,25 @@
 using System;
 using System.Collections.Generic;
-using System.Runtime.InteropServices;
+using System.Linq;
 using UnityEngine;
+#if UNITY_EDITOR_WIN
+using System.Runtime.InteropServices;
+#endif
+#if HAS_INPUT_SYSTEM
+using UnityEngine.InputSystem;
+using UnityEngine.InputSystem.LowLevel;
+#endif
 
 namespace UnityMcpPro
 {
     public class InputCommands : BaseCommand
     {
         // Track which keys are currently "held" by simulation
+#if UNITY_EDITOR_WIN
         private static HashSet<ushort> _heldScanCodes = new HashSet<ushort>();
+#elif HAS_INPUT_SYSTEM
+        private static HashSet<Key> _heldInputKeys = new HashSet<Key>();
+#endif
 
         public static void Register(CommandRouter router)
         {
@@ -27,8 +38,9 @@ namespace UnityMcpPro
         private static float _recordStartTime;
         private static List<Dictionary<string, object>> _recordedEvents = new List<Dictionary<string, object>>();
 
+#if UNITY_EDITOR_WIN
         // =================================================================
-        // Win32 API declarations
+        // Win32 API declarations (Windows Editor only)
         // =================================================================
         [DllImport("user32.dll", SetLastError = true)]
         private static extern uint SendInput(uint nInputs, INPUT[] pInputs, int cbSize);
@@ -36,21 +48,24 @@ namespace UnityMcpPro
         [DllImport("user32.dll")]
         private static extern short GetAsyncKeyState(int vKey);
 
-        [StructLayout(LayoutKind.Sequential)]
+        [DllImport("user32.dll")]
+        private static extern uint MapVirtualKey(uint uCode, uint uMapType);
+
+        [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
         private struct INPUT
         {
             public uint type;
             public INPUTUNION u;
         }
 
-        [StructLayout(LayoutKind.Explicit)]
+        [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Explicit)]
         private struct INPUTUNION
         {
-            [FieldOffset(0)] public KEYBDINPUT ki;
-            [FieldOffset(0)] public MOUSEINPUT mi;
+            [System.Runtime.InteropServices.FieldOffset(0)] public KEYBDINPUT ki;
+            [System.Runtime.InteropServices.FieldOffset(0)] public MOUSEINPUT mi;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
+        [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
         private struct KEYBDINPUT
         {
             public ushort wVk;
@@ -60,7 +75,7 @@ namespace UnityMcpPro
             public IntPtr dwExtraInfo;
         }
 
-        [StructLayout(LayoutKind.Sequential)]
+        [System.Runtime.InteropServices.StructLayout(System.Runtime.InteropServices.LayoutKind.Sequential)]
         private struct MOUSEINPUT
         {
             public int dx;
@@ -86,8 +101,14 @@ namespace UnityMcpPro
         private const uint MOUSEEVENTF_WHEEL = 0x0800;
         private const uint MOUSEEVENTF_ABSOLUTE = 0x8000;
 
+        private static ushort MapVKToScan(ushort vk)
+        {
+            return (ushort)MapVirtualKey(vk, 0); // MAPVK_VK_TO_VSC
+        }
+#endif
+
         // =================================================================
-        // simulate_key — キーボードキーのプレス/リリース/タップ (Win32 SendInput)
+        // simulate_key
         // =================================================================
         private static object SimulateKey(Dictionary<string, object> p)
         {
@@ -98,6 +119,7 @@ namespace UnityMcpPro
             if (string.IsNullOrEmpty(keyName))
                 throw new ArgumentException("key is required (e.g. 'Space', 'W', 'A', 'LeftArrow')");
 
+#if UNITY_EDITOR_WIN
             ushort vk = MapKeyNameToVK(keyName);
             ushort scan = MapVKToScan(vk);
 
@@ -135,10 +157,58 @@ namespace UnityMcpPro
                 default:
                     throw new ArgumentException($"Unknown action '{action}'. Use 'press', 'release', or 'tap'.");
             }
+#elif HAS_INPUT_SYSTEM
+            var keyboard = Keyboard.current;
+            if (keyboard == null)
+                throw new InvalidOperationException("No keyboard device found. Ensure a keyboard is connected and Input System is active.");
+
+            Key key = MapKeyNameToInputSystemKey(keyName);
+
+            switch (action.ToLower())
+            {
+                case "press":
+                    _heldInputKeys.Add(key);
+                    InputSystem.QueueStateEvent(keyboard, new KeyboardState(_heldInputKeys.ToArray()));
+                    return Success($"Key '{keyName}' pressed (held down)");
+
+                case "release":
+                    _heldInputKeys.Remove(key);
+                    InputSystem.QueueStateEvent(keyboard, _heldInputKeys.Count > 0
+                        ? new KeyboardState(_heldInputKeys.ToArray())
+                        : new KeyboardState());
+                    return Success($"Key '{keyName}' released");
+
+                case "tap":
+                    _heldInputKeys.Add(key);
+                    InputSystem.QueueStateEvent(keyboard, new KeyboardState(_heldInputKeys.ToArray()));
+                    float tapReleaseTime = (float)UnityEditor.EditorApplication.timeSinceStartup + duration;
+                    var capturedKey = key;
+                    UnityEditor.EditorApplication.CallbackFunction tapCallback = null;
+                    tapCallback = () =>
+                    {
+                        if (UnityEditor.EditorApplication.timeSinceStartup >= tapReleaseTime)
+                        {
+                            _heldInputKeys.Remove(capturedKey);
+                            InputSystem.QueueStateEvent(Keyboard.current, _heldInputKeys.Count > 0
+                                ? new KeyboardState(_heldInputKeys.ToArray())
+                                : new KeyboardState());
+                            UnityEditor.EditorApplication.update -= tapCallback;
+                        }
+                    };
+                    UnityEditor.EditorApplication.update += tapCallback;
+                    return Success($"Key '{keyName}' tapped (duration: {duration}s)");
+
+                default:
+                    throw new ArgumentException($"Unknown action '{action}'. Use 'press', 'release', or 'tap'.");
+            }
+#else
+            throw new PlatformNotSupportedException(
+                "simulate_key is not supported on this platform without the New Input System package (com.unity.inputsystem).");
+#endif
         }
 
         // =================================================================
-        // simulate_mouse — マウス移動/クリック (Win32 SendInput)
+        // simulate_mouse
         // =================================================================
         private static object SimulateMouse(Dictionary<string, object> p)
         {
@@ -147,6 +217,7 @@ namespace UnityMcpPro
             float y = GetFloatParam(p, "y", 0);
             string button = GetStringParam(p, "button", "left");
 
+#if UNITY_EDITOR_WIN
             switch (action.ToLower())
             {
                 case "move":
@@ -176,10 +247,51 @@ namespace UnityMcpPro
                 default:
                     throw new ArgumentException($"Unknown action '{action}'.");
             }
+#elif HAS_INPUT_SYSTEM
+            var mouse = Mouse.current;
+            if (mouse == null)
+                throw new InvalidOperationException("No mouse device found.");
+
+            switch (action.ToLower())
+            {
+                case "move":
+                    bool relative = p.ContainsKey("relative") && Convert.ToBoolean(p["relative"]);
+                    var targetPos = relative
+                        ? mouse.position.ReadValue() + new UnityEngine.Vector2(x, y)
+                        : new UnityEngine.Vector2(x, y);
+                    InputSystem.QueueStateEvent(mouse, new MouseState { position = targetPos });
+                    return Success($"Mouse moved to ({targetPos.x}, {targetPos.y})");
+
+                case "click":
+                    var clickMask = GetMouseButtonMaskInputSystem(button);
+                    InputSystem.QueueStateEvent(mouse, new MouseState { buttons = clickMask });
+                    UnityEditor.EditorApplication.delayCall += () =>
+                        InputSystem.QueueStateEvent(Mouse.current, new MouseState { buttons = 0 });
+                    return Success($"Mouse {button} clicked");
+
+                case "press":
+                    InputSystem.QueueStateEvent(mouse, new MouseState { buttons = GetMouseButtonMaskInputSystem(button) });
+                    return Success($"Mouse {button} pressed");
+
+                case "release":
+                    InputSystem.QueueStateEvent(mouse, new MouseState { buttons = 0 });
+                    return Success($"Mouse {button} released");
+
+                case "scroll":
+                    InputSystem.QueueStateEvent(mouse, new MouseState { scroll = new UnityEngine.Vector2(0, y) });
+                    return Success($"Mouse scrolled {y}");
+
+                default:
+                    throw new ArgumentException($"Unknown action '{action}'.");
+            }
+#else
+            throw new PlatformNotSupportedException(
+                "simulate_mouse is not supported on this platform without the New Input System package (com.unity.inputsystem).");
+#endif
         }
 
         // =================================================================
-        // simulate_axis — 軸入力シミュレーション (WASD via Win32)
+        // simulate_axis
         // =================================================================
         private static object SimulateAxis(Dictionary<string, object> p)
         {
@@ -187,6 +299,7 @@ namespace UnityMcpPro
             float vertical = GetFloatParam(p, "vertical", 0);
             float duration = GetFloatParam(p, "duration", 0.1f);
 
+#if UNITY_EDITOR_WIN
             var keysToPress = new List<(ushort vk, ushort scan)>();
             var keysToRelease = new List<(ushort vk, ushort scan)>();
 
@@ -231,34 +344,122 @@ namespace UnityMcpPro
                 { "duration", duration },
                 { "keysPressed", string.Join(", ", pressedNames) }
             });
+#elif HAS_INPUT_SYSTEM
+            var keyboard = Keyboard.current;
+            if (keyboard == null)
+                throw new InvalidOperationException("No keyboard device found.");
+
+            // Release opposing keys first, then press the requested ones
+            var toRelease = new List<Key>();
+            var toPress = new List<Key>();
+
+            if (horizontal < -0.1f) { toPress.Add(Key.A); toRelease.Add(Key.D); }
+            else if (horizontal > 0.1f) { toPress.Add(Key.D); toRelease.Add(Key.A); }
+            else { toRelease.Add(Key.A); toRelease.Add(Key.D); }
+
+            if (vertical < -0.1f) { toPress.Add(Key.S); toRelease.Add(Key.W); }
+            else if (vertical > 0.1f) { toPress.Add(Key.W); toRelease.Add(Key.S); }
+            else { toRelease.Add(Key.W); toRelease.Add(Key.S); }
+
+            foreach (var k in toRelease) _heldInputKeys.Remove(k);
+            foreach (var k in toPress) _heldInputKeys.Add(k);
+
+            InputSystem.QueueStateEvent(keyboard, _heldInputKeys.Count > 0
+                ? new KeyboardState(_heldInputKeys.ToArray())
+                : new KeyboardState());
+
+            if (duration > 0)
+            {
+                float releaseTime = (float)UnityEditor.EditorApplication.timeSinceStartup + duration;
+                var pressed = new List<Key>(toPress);
+                UnityEditor.EditorApplication.CallbackFunction cb = null;
+                cb = () =>
+                {
+                    if (UnityEditor.EditorApplication.timeSinceStartup >= releaseTime)
+                    {
+                        foreach (var k in pressed) _heldInputKeys.Remove(k);
+                        InputSystem.QueueStateEvent(Keyboard.current, _heldInputKeys.Count > 0
+                            ? new KeyboardState(_heldInputKeys.ToArray())
+                            : new KeyboardState());
+                        UnityEditor.EditorApplication.update -= cb;
+                    }
+                };
+                UnityEditor.EditorApplication.update += cb;
+            }
+
+            return Success(new Dictionary<string, object>
+            {
+                { "horizontal", horizontal },
+                { "vertical", vertical },
+                { "duration", duration },
+                { "keysPressed", string.Join(", ", toPress) }
+            });
+#else
+            throw new PlatformNotSupportedException(
+                "simulate_axis is not supported on this platform without the New Input System package (com.unity.inputsystem).");
+#endif
         }
 
         // =================================================================
-        // get_input_state — 現在の入力状態を取得
+        // get_input_state
         // =================================================================
         private static object GetInputState(Dictionary<string, object> p)
         {
             var result = new Dictionary<string, object>();
-
-            // Check common keys via Win32 GetAsyncKeyState
             var pressedKeys = new List<string>();
+
+#if UNITY_EDITOR_WIN
             var keyChecks = new (string name, int vk)[] {
                 ("W", 0x57), ("A", 0x41), ("S", 0x53), ("D", 0x44),
                 ("Space", 0x20), ("Enter", 0x0D), ("Escape", 0x1B),
                 ("Up", 0x26), ("Down", 0x28), ("Left", 0x25), ("Right", 0x27),
                 ("Shift", 0x10), ("Ctrl", 0x11), ("Alt", 0x12),
-                ("R", 0x52), ("E", 0x45), ("Q", 0x51), ("F", 0x46),
-                ("Tab", 0x09)
+                ("R", 0x52), ("E", 0x45), ("Q", 0x51), ("F", 0x46), ("Tab", 0x09)
             };
             foreach (var (name, vk) in keyChecks)
             {
                 if ((GetAsyncKeyState(vk) & 0x8000) != 0)
                     pressedKeys.Add(name);
             }
-            result["pressedKeys"] = pressedKeys;
             result["heldBySim"] = _heldScanCodes.Count;
+#elif HAS_INPUT_SYSTEM
+            var keyboard = Keyboard.current;
+            if (keyboard != null)
+            {
+                var keyChecks = new (string name, Key key)[] {
+                    ("W", Key.W), ("A", Key.A), ("S", Key.S), ("D", Key.D),
+                    ("Space", Key.Space), ("Enter", Key.Enter), ("Escape", Key.Escape),
+                    ("Up", Key.UpArrow), ("Down", Key.DownArrow), ("Left", Key.LeftArrow), ("Right", Key.RightArrow),
+                    ("Shift", Key.LeftShift), ("Ctrl", Key.LeftCtrl), ("Alt", Key.LeftAlt),
+                    ("R", Key.R), ("E", Key.E), ("Q", Key.Q), ("F", Key.F), ("Tab", Key.Tab)
+                };
+                foreach (var (name, key) in keyChecks)
+                {
+                    if (keyboard[key].isPressed)
+                        pressedKeys.Add(name);
+                }
+            }
+            result["heldBySim"] = _heldInputKeys.Count;
+#else
+            if (UnityEditor.EditorApplication.isPlaying)
+            {
+                var keyChecks = new (string name, KeyCode kc)[] {
+                    ("W", KeyCode.W), ("A", KeyCode.A), ("S", KeyCode.S), ("D", KeyCode.D),
+                    ("Space", KeyCode.Space), ("Enter", KeyCode.Return), ("Escape", KeyCode.Escape),
+                    ("Up", KeyCode.UpArrow), ("Down", KeyCode.DownArrow),
+                    ("Left", KeyCode.LeftArrow), ("Right", KeyCode.RightArrow),
+                    ("Shift", KeyCode.LeftShift), ("R", KeyCode.R), ("E", KeyCode.E),
+                    ("Q", KeyCode.Q), ("F", KeyCode.F), ("Tab", KeyCode.Tab)
+                };
+                foreach (var (name, kc) in keyChecks)
+                {
+                    try { if (Input.GetKey(kc)) pressedKeys.Add(name); } catch { }
+                }
+            }
+            result["heldBySim"] = 0;
+#endif
+            result["pressedKeys"] = pressedKeys;
 
-            // Old Input Manager values (in play mode)
             if (UnityEditor.EditorApplication.isPlaying)
             {
                 try
@@ -273,6 +474,7 @@ namespace UnityMcpPro
             return result;
         }
 
+#if UNITY_EDITOR_WIN
         // =================================================================
         // Win32 SendInput helpers
         // =================================================================
@@ -283,17 +485,10 @@ namespace UnityMcpPro
                 type = INPUT_KEYBOARD,
                 u = new INPUTUNION
                 {
-                    ki = new KEYBDINPUT
-                    {
-                        wVk = vk,
-                        wScan = scan,
-                        dwFlags = KEYEVENTF_KEYDOWN,
-                        time = 0,
-                        dwExtraInfo = IntPtr.Zero
-                    }
+                    ki = new KEYBDINPUT { wVk = vk, wScan = scan, dwFlags = KEYEVENTF_KEYDOWN, time = 0, dwExtraInfo = IntPtr.Zero }
                 }
             };
-            SendInput(1, new[] { input }, Marshal.SizeOf<INPUT>());
+            SendInput(1, new[] { input }, System.Runtime.InteropServices.Marshal.SizeOf<INPUT>());
         }
 
         private static void SendKeyUp(ushort vk, ushort scan)
@@ -303,17 +498,10 @@ namespace UnityMcpPro
                 type = INPUT_KEYBOARD,
                 u = new INPUTUNION
                 {
-                    ki = new KEYBDINPUT
-                    {
-                        wVk = vk,
-                        wScan = scan,
-                        dwFlags = KEYEVENTF_KEYUP,
-                        time = 0,
-                        dwExtraInfo = IntPtr.Zero
-                    }
+                    ki = new KEYBDINPUT { wVk = vk, wScan = scan, dwFlags = KEYEVENTF_KEYUP, time = 0, dwExtraInfo = IntPtr.Zero }
                 }
             };
-            SendInput(1, new[] { input }, Marshal.SizeOf<INPUT>());
+            SendInput(1, new[] { input }, System.Runtime.InteropServices.Marshal.SizeOf<INPUT>());
         }
 
         private static void SendMouseMove(int dx, int dy)
@@ -323,15 +511,10 @@ namespace UnityMcpPro
                 type = INPUT_MOUSE,
                 u = new INPUTUNION
                 {
-                    mi = new MOUSEINPUT
-                    {
-                        dx = dx, dy = dy,
-                        dwFlags = MOUSEEVENTF_MOVE,
-                        mouseData = 0, time = 0, dwExtraInfo = IntPtr.Zero
-                    }
+                    mi = new MOUSEINPUT { dx = dx, dy = dy, dwFlags = MOUSEEVENTF_MOVE, mouseData = 0, time = 0, dwExtraInfo = IntPtr.Zero }
                 }
             };
-            SendInput(1, new[] { input }, Marshal.SizeOf<INPUT>());
+            SendInput(1, new[] { input }, System.Runtime.InteropServices.Marshal.SizeOf<INPUT>());
         }
 
         private static void SendMouseButton(uint flags)
@@ -341,15 +524,10 @@ namespace UnityMcpPro
                 type = INPUT_MOUSE,
                 u = new INPUTUNION
                 {
-                    mi = new MOUSEINPUT
-                    {
-                        dx = 0, dy = 0,
-                        dwFlags = flags,
-                        mouseData = 0, time = 0, dwExtraInfo = IntPtr.Zero
-                    }
+                    mi = new MOUSEINPUT { dx = 0, dy = 0, dwFlags = flags, mouseData = 0, time = 0, dwExtraInfo = IntPtr.Zero }
                 }
             };
-            SendInput(1, new[] { input }, Marshal.SizeOf<INPUT>());
+            SendInput(1, new[] { input }, System.Runtime.InteropServices.Marshal.SizeOf<INPUT>());
         }
 
         private static void SendMouseScroll(int amount)
@@ -359,41 +537,39 @@ namespace UnityMcpPro
                 type = INPUT_MOUSE,
                 u = new INPUTUNION
                 {
-                    mi = new MOUSEINPUT
-                    {
-                        dx = 0, dy = 0,
-                        dwFlags = MOUSEEVENTF_WHEEL,
-                        mouseData = (uint)amount, time = 0, dwExtraInfo = IntPtr.Zero
-                    }
+                    mi = new MOUSEINPUT { dx = 0, dy = 0, dwFlags = MOUSEEVENTF_WHEEL, mouseData = (uint)amount, time = 0, dwExtraInfo = IntPtr.Zero }
                 }
             };
-            SendInput(1, new[] { input }, Marshal.SizeOf<INPUT>());
+            SendInput(1, new[] { input }, System.Runtime.InteropServices.Marshal.SizeOf<INPUT>());
         }
 
         private static void GetMouseButtonFlags(string button, out uint downFlag, out uint upFlag)
         {
             switch (button.ToLower())
             {
-                case "left": downFlag = MOUSEEVENTF_LEFTDOWN; upFlag = MOUSEEVENTF_LEFTUP; break;
-                case "right": downFlag = MOUSEEVENTF_RIGHTDOWN; upFlag = MOUSEEVENTF_RIGHTUP; break;
+                case "left":   downFlag = MOUSEEVENTF_LEFTDOWN;   upFlag = MOUSEEVENTF_LEFTUP;   break;
+                case "right":  downFlag = MOUSEEVENTF_RIGHTDOWN;  upFlag = MOUSEEVENTF_RIGHTUP;  break;
                 case "middle": downFlag = MOUSEEVENTF_MIDDLEDOWN; upFlag = MOUSEEVENTF_MIDDLEUP; break;
                 default: throw new ArgumentException($"Unknown mouse button '{button}'");
             }
         }
+#endif
 
-        // =================================================================
-        // Virtual Key code mapping
-        // =================================================================
-        [DllImport("user32.dll")]
-        private static extern uint MapVirtualKey(uint uCode, uint uMapType);
-
-        private static ushort MapVKToScan(ushort vk)
+#if HAS_INPUT_SYSTEM && !UNITY_EDITOR_WIN
+        private static byte GetMouseButtonMaskInputSystem(string button)
         {
-            return (ushort)MapVirtualKey(vk, 0); // MAPVK_VK_TO_VSC
+            switch (button.ToLower())
+            {
+                case "left":   return (byte)MouseButton.Left;
+                case "right":  return (byte)MouseButton.Right;
+                case "middle": return (byte)MouseButton.Middle;
+                default: throw new ArgumentException($"Unknown mouse button '{button}'");
+            }
         }
+#endif
 
         // =================================================================
-        // simulate_sequence — 入力シーケンスの一括実行
+        // simulate_sequence
         // =================================================================
         private static object SimulateSequence(Dictionary<string, object> p)
         {
@@ -414,15 +590,9 @@ namespace UnityMcpPro
 
                 switch (type.ToLower())
                 {
-                    case "key":
-                        SimulateKey(action);
-                        break;
-                    case "mouse":
-                        SimulateMouse(action);
-                        break;
-                    case "axis":
-                        SimulateAxis(action);
-                        break;
+                    case "key":   SimulateKey(action);   break;
+                    case "mouse": SimulateMouse(action); break;
+                    case "axis":  SimulateAxis(action);  break;
                     case "wait":
                         System.Threading.Thread.Sleep((int)(duration * 1000));
                         totalDelay += duration;
@@ -451,8 +621,6 @@ namespace UnityMcpPro
             _recordedEvents.Clear();
             _recordStartTime = (float)UnityEditor.EditorApplication.timeSinceStartup;
             _isRecording = true;
-
-            // Hook into update to poll key states
             UnityEditor.EditorApplication.update += RecordingPollCallback;
 
             return new Dictionary<string, object>
@@ -473,35 +641,62 @@ namespace UnityMcpPro
 
             float elapsed = (float)UnityEditor.EditorApplication.timeSinceStartup - _recordStartTime;
 
-            // Poll common keys
+#if UNITY_EDITOR_WIN
             var keyChecks = new (string name, int vk)[] {
                 ("W", 0x57), ("A", 0x41), ("S", 0x53), ("D", 0x44),
                 ("Space", 0x20), ("Enter", 0x0D), ("Escape", 0x1B),
                 ("R", 0x52), ("E", 0x45), ("Q", 0x51), ("F", 0x46)
             };
-
             foreach (var (name, vk) in keyChecks)
             {
                 if ((GetAsyncKeyState(vk) & 0x8000) != 0)
+                    RecordKeyEvent(name, elapsed);
+            }
+#elif HAS_INPUT_SYSTEM
+            var keyboard = Keyboard.current;
+            if (keyboard != null)
+            {
+                var keyChecks = new (string name, Key key)[] {
+                    ("W", Key.W), ("A", Key.A), ("S", Key.S), ("D", Key.D),
+                    ("Space", Key.Space), ("Enter", Key.Enter), ("Escape", Key.Escape),
+                    ("R", Key.R), ("E", Key.E), ("Q", Key.Q), ("F", Key.F)
+                };
+                foreach (var (name, key) in keyChecks)
                 {
-                    _recordedEvents.Add(new Dictionary<string, object>
-                    {
-                        { "type", "key" },
-                        { "timestamp", Math.Round(elapsed, 3) },
-                        { "data", new Dictionary<string, object> { { "key", name }, { "action", "press" } } }
-                    });
+                    if (keyboard[key].isPressed)
+                        RecordKeyEvent(name, elapsed);
                 }
             }
+#else
+            if (UnityEditor.EditorApplication.isPlaying)
+            {
+                var keyChecks = new (string name, KeyCode kc)[] {
+                    ("W", KeyCode.W), ("A", KeyCode.A), ("S", KeyCode.S), ("D", KeyCode.D),
+                    ("Space", KeyCode.Space), ("Enter", KeyCode.Return), ("Escape", KeyCode.Escape),
+                    ("R", KeyCode.R), ("E", KeyCode.E), ("Q", KeyCode.Q), ("F", KeyCode.F)
+                };
+                foreach (var (name, kc) in keyChecks)
+                {
+                    try { if (Input.GetKey(kc)) RecordKeyEvent(name, elapsed); } catch { }
+                }
+            }
+#endif
+        }
+
+        private static void RecordKeyEvent(string name, float elapsed)
+        {
+            _recordedEvents.Add(new Dictionary<string, object>
+            {
+                { "type", "key" },
+                { "timestamp", Math.Round(elapsed, 3) },
+                { "data", new Dictionary<string, object> { { "key", name }, { "action", "press" } } }
+            });
         }
 
         private static object StopRecording(Dictionary<string, object> p)
         {
             if (!_isRecording)
-                return new Dictionary<string, object>
-                {
-                    { "success", false },
-                    { "message", "No recording in progress" }
-                };
+                return new Dictionary<string, object> { { "success", false }, { "message", "No recording in progress" } };
 
             _isRecording = false;
             UnityEditor.EditorApplication.update -= RecordingPollCallback;
@@ -534,10 +729,7 @@ namespace UnityMcpPro
                 if (evt == null) continue;
 
                 float timestamp = evt.ContainsKey("timestamp") ? Convert.ToSingle(evt["timestamp"]) : 0f;
-                float adjustedDelay = timestamp / speed;
-
-                // Wait until the right time
-                float targetTime = startTime + adjustedDelay;
+                float targetTime = startTime + timestamp / speed;
                 while ((float)UnityEditor.EditorApplication.timeSinceStartup < targetTime)
                     System.Threading.Thread.Sleep(10);
 
@@ -546,12 +738,8 @@ namespace UnityMcpPro
 
                 switch (type)
                 {
-                    case "key":
-                        if (data != null) SimulateKey(data);
-                        break;
-                    case "mouse":
-                        if (data != null) SimulateMouse(data);
-                        break;
+                    case "key":   if (data != null) SimulateKey(data);   break;
+                    case "mouse": if (data != null) SimulateMouse(data); break;
                 }
                 replayed++;
             }
@@ -565,6 +753,9 @@ namespace UnityMcpPro
             };
         }
 
+        // =================================================================
+        // Key name → Virtual Key code (Windows)
+        // =================================================================
         private static ushort MapKeyNameToVK(string name)
         {
             switch (name.ToLower())
@@ -597,11 +788,59 @@ namespace UnityMcpPro
                 case "4": return 0x34;
                 case "5": return 0x35;
                 default:
-                    // Try single character
                     if (name.Length == 1 && char.IsLetterOrDigit(name[0]))
                         return (ushort)char.ToUpper(name[0]);
                     throw new ArgumentException($"Unknown key '{name}'. Examples: Space, W, A, S, D, Enter, Escape, LeftArrow");
             }
         }
+
+#if HAS_INPUT_SYSTEM && !UNITY_EDITOR_WIN
+        // =================================================================
+        // Key name → Input System Key (Linux / macOS)
+        // =================================================================
+        private static Key MapKeyNameToInputSystemKey(string name)
+        {
+            switch (name.ToLower())
+            {
+                case "space": return Key.Space;
+                case "enter": case "return": return Key.Enter;
+                case "escape": case "esc": return Key.Escape;
+                case "tab": return Key.Tab;
+                case "backspace": return Key.Backspace;
+                case "delete": return Key.Delete;
+                case "leftshift": case "lshift": case "shift": return Key.LeftShift;
+                case "rightshift": case "rshift": return Key.RightShift;
+                case "leftctrl": case "lctrl": case "ctrl": return Key.LeftCtrl;
+                case "rightctrl": case "rctrl": return Key.RightCtrl;
+                case "leftalt": case "lalt": case "alt": return Key.LeftAlt;
+                case "rightalt": case "ralt": return Key.RightAlt;
+                case "uparrow": case "up": return Key.UpArrow;
+                case "downarrow": case "down": return Key.DownArrow;
+                case "leftarrow": case "left": return Key.LeftArrow;
+                case "rightarrow": case "right": return Key.RightArrow;
+                case "w": return Key.W;
+                case "a": return Key.A;
+                case "s": return Key.S;
+                case "d": return Key.D;
+                case "r": return Key.R;
+                case "e": return Key.E;
+                case "q": return Key.Q;
+                case "f": return Key.F;
+                case "1": return Key.Digit1;
+                case "2": return Key.Digit2;
+                case "3": return Key.Digit3;
+                case "4": return Key.Digit4;
+                case "5": return Key.Digit5;
+                default:
+                    if (name.Length == 1)
+                    {
+                        char c = char.ToUpper(name[0]);
+                        if (System.Enum.TryParse<Key>(c.ToString(), out Key k)) return k;
+                        if (c >= '0' && c <= '9' && System.Enum.TryParse<Key>("Digit" + c, out Key dk)) return dk;
+                    }
+                    throw new ArgumentException($"Unknown key '{name}'. Examples: Space, W, A, S, D, Enter, Escape, LeftArrow");
+            }
+        }
+#endif
     }
 }

--- a/Editor/Commands/InputCommands.cs
+++ b/Editor/Commands/InputCommands.cs
@@ -556,13 +556,13 @@ namespace UnityMcpPro
 #endif
 
 #if HAS_INPUT_SYSTEM && !UNITY_EDITOR_WIN
-        private static byte GetMouseButtonMaskInputSystem(string button)
+        private static ushort GetMouseButtonMaskInputSystem(string button)
         {
             switch (button.ToLower())
             {
-                case "left":   return (byte)MouseButton.Left;
-                case "right":  return (byte)MouseButton.Right;
-                case "middle": return (byte)MouseButton.Middle;
+                case "left":   return (ushort)(1 << (int)MouseButton.Left);
+                case "right":  return (ushort)(1 << (int)MouseButton.Right);
+                case "middle": return (ushort)(1 << (int)MouseButton.Middle);
                 default: throw new ArgumentException($"Unknown mouse button '{button}'");
             }
         }

--- a/Editor/Commands/ScreenshotCommands.cs
+++ b/Editor/Commands/ScreenshotCommands.cs
@@ -81,35 +81,63 @@ namespace UnityMcpPro
             string format = GetStringParam(p, "format", "jpg");
             int quality = GetIntParam(p, "quality", 75);
 
-            Camera gameCamera = Camera.main;
-            if (gameCamera == null)
+            Texture2D tex;
+            string source;
+
+            if (Application.isPlaying)
             {
-                var cameras = Camera.allCameras;
-                if (cameras.Length > 0)
-                    gameCamera = cameras[0];
+                // CaptureScreenshotAsTexture captures the fully composited frame,
+                // including ScreenSpaceOverlay canvases that camera.Render() misses.
+                tex = ScreenCapture.CaptureScreenshotAsTexture();
+                source = "screen_capture";
+            }
+            else
+            {
+                Camera gameCamera = Camera.main;
+                if (gameCamera == null)
+                {
+                    var cameras = Camera.allCameras;
+                    if (cameras.Length > 0)
+                        gameCamera = cameras[0];
+                }
+                if (gameCamera == null)
+                    throw new InvalidOperationException("No camera found in the scene");
+
+                var rt = new RenderTexture(width, height, 24);
+                var prevRT = gameCamera.targetTexture;
+                gameCamera.targetTexture = rt;
+                gameCamera.Render();
+                gameCamera.targetTexture = prevRT;
+
+                RenderTexture.active = rt;
+                tex = new Texture2D(width, height, TextureFormat.RGB24, false);
+                tex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+                tex.Apply();
+                RenderTexture.active = null;
+                rt.Release();
+                UnityEngine.Object.DestroyImmediate(rt);
+                source = "game_camera";
             }
 
-            if (gameCamera == null)
-                throw new InvalidOperationException("No camera found in the scene");
-
-            var rt = new RenderTexture(width, height, 24);
-            var prevRT = gameCamera.targetTexture;
-            gameCamera.targetTexture = rt;
-            gameCamera.Render();
-            gameCamera.targetTexture = prevRT;
-
-            RenderTexture.active = rt;
-            var tex = new Texture2D(width, height, TextureFormat.RGB24, false);
-            tex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
-            tex.Apply();
-            RenderTexture.active = null;
+            // Resize to requested dimensions if the captured size differs
+            if (tex.width != width || tex.height != height)
+            {
+                var resizeRt = new RenderTexture(width, height, 0);
+                Graphics.Blit(tex, resizeRt);
+                RenderTexture.active = resizeRt;
+                var resizedTex = new Texture2D(width, height, TextureFormat.RGB24, false);
+                resizedTex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+                resizedTex.Apply();
+                RenderTexture.active = null;
+                UnityEngine.Object.DestroyImmediate(tex);
+                resizeRt.Release();
+                UnityEngine.Object.DestroyImmediate(resizeRt);
+                tex = resizedTex;
+            }
 
             byte[] imageData = EncodeTexture(tex, format, quality);
             string base64 = Convert.ToBase64String(imageData);
-
             UnityEngine.Object.DestroyImmediate(tex);
-            rt.Release();
-            UnityEngine.Object.DestroyImmediate(rt);
 
             return new Dictionary<string, object>
             {
@@ -118,8 +146,7 @@ namespace UnityMcpPro
                 { "height", height },
                 { "format", format },
                 { "mimeType", GetMimeType(format) },
-                { "source", "game_camera" },
-                { "cameraName", gameCamera.name }
+                { "source", source }
             };
         }
 


### PR DESCRIPTION
# fix: cross-platform simulate_key and game screenshot UI overlay capture

## Summary

Two bugs affecting Linux/macOS Editor users and ScreenSpaceOverlay UI capture.

### Bug 1 — `get_game_screenshot` misses ScreenSpaceOverlay canvases

The previous implementation rendered the scene camera directly into a `RenderTexture` via `camera.Render()`. Unity composites ScreenSpaceOverlay canvases onto the screen buffer *after* the camera renders, so they were never present in the captured texture.

**Fix:** In play mode, `ScreenCapture.CaptureScreenshotAsTexture()` is used instead, which captures the fully composited frame including all overlay canvases. A resize step is added so the requested `width`/`height` is always respected regardless of the native screen resolution. The original `camera.Render()` path is kept as a fallback for edit mode.

### Bug 2 — `simulate_key` crashes on Linux/macOS Editor

`InputCommands` called `MapVirtualKey` (Win32 `user32.dll`) unconditionally on all platforms. On Linux and macOS there is no `user32.dll`, causing a P/Invoke native crash immediately on any `simulate_key` call.

**Fix:** All Win32 P/Invoke declarations and call sites (`SendInput`, `MapVirtualKey`, `GetAsyncKeyState`) are guarded with `#if UNITY_EDITOR_WIN`. A cross-platform fallback is added under `#if HAS_INPUT_SYSTEM` (already defined in the package's asmdef `versionDefines`) that uses `InputSystem.QueueStateEvent` with `KeyboardState`/`MouseState`, making key and mouse simulation fully functional on Linux and macOS. If neither Windows nor Input System is available, a clear `PlatformNotSupportedException` is thrown instead of crashing.

## Files changed

- `Editor/Commands/ScreenshotCommands.cs` — `GetGameScreenshot`
- `Editor/Commands/InputCommands.cs` — `SimulateKey`, `SimulateMouse`, `SimulateAxis`, `GetInputState`, `RecordingPollCallback`

## Testing

- **Linux Editor:** `simulate_key` with `Space` no longer crashes; key events are delivered via Input System
- **Play mode screenshot:** `get_game_screenshot` now captures a runtime-spawned ScreenSpaceOverlay canvas with a visible UI element that was previously absent from the returned image
- **Windows Editor:** existing Win32 path unchanged, all prior behaviour preserved
