### PR TITLE
fix: capture game screenshots from Game View RT instead of editor framebuffer

### DIFF
--- a/Editor/Commands/ScreenshotCommands.cs
+++ b/Editor/Commands/ScreenshotCommands.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
@@ -7,12 +8,31 @@ namespace UnityMcpPro
 {
     public class ScreenshotCommands : BaseCommand
     {
+        private static readonly Dictionary<string, CaptureSession> _captureSessions
+            = new Dictionary<string, CaptureSession>();
+
+        private class CaptureSession
+        {
+            public List<Dictionary<string, object>> frames = new List<Dictionary<string, object>>();
+            public int targetCount;
+            public int width;
+            public int height;
+            public int quality;
+            public string format;
+            public float interval;
+            public float nextCapture;
+            public bool complete;
+            public string source;
+            public double createdAt;
+        }
+
         public static void Register(CommandRouter router)
         {
             router.Register("get_editor_screenshot", GetEditorScreenshot);
             router.Register("get_game_screenshot", GetGameScreenshot);
             router.Register("compare_screenshots", CompareScreenshots);
             router.Register("capture_frames", CaptureFrames);
+            router.Register("get_captured_frames", GetCapturedFrames);
         }
 
         private static byte[] EncodeTexture(Texture2D tex, string format, int quality)
@@ -86,36 +106,26 @@ namespace UnityMcpPro
 
             if (Application.isPlaying)
             {
-                // CaptureScreenshotAsTexture captures the fully composited frame,
-                // including ScreenSpaceOverlay canvases that camera.Render() misses.
-                tex = ScreenCapture.CaptureScreenshotAsTexture();
-                source = "screen_capture";
+                // Read directly from the Game View's internal RenderTexture.
+                // ScreenCapture.CaptureScreenshotAsTexture() requires end-of-frame
+                // timing; called synchronously from the MCP handler it reads the
+                // editor's framebuffer instead, producing chrome and artifacts.
+                tex = CaptureGameViewTexture();
+                if (tex != null)
+                {
+                    source = "game_view";
+                }
+                else
+                {
+                    // Fallback: render main camera to a temporary RT.
+                    // This won't include ScreenSpaceOverlay UI but avoids artifacts.
+                    tex = RenderCameraToTexture(width, height);
+                    source = "camera_render";
+                }
             }
             else
             {
-                Camera gameCamera = Camera.main;
-                if (gameCamera == null)
-                {
-                    var cameras = Camera.allCameras;
-                    if (cameras.Length > 0)
-                        gameCamera = cameras[0];
-                }
-                if (gameCamera == null)
-                    throw new InvalidOperationException("No camera found in the scene");
-
-                var rt = new RenderTexture(width, height, 24);
-                var prevRT = gameCamera.targetTexture;
-                gameCamera.targetTexture = rt;
-                gameCamera.Render();
-                gameCamera.targetTexture = prevRT;
-
-                RenderTexture.active = rt;
-                tex = new Texture2D(width, height, TextureFormat.RGB24, false);
-                tex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
-                tex.Apply();
-                RenderTexture.active = null;
-                rt.Release();
-                UnityEngine.Object.DestroyImmediate(rt);
+                tex = RenderCameraToTexture(width, height);
                 source = "game_camera";
             }
 
@@ -148,6 +158,82 @@ namespace UnityMcpPro
                 { "mimeType", GetMimeType(format) },
                 { "source", source }
             };
+        }
+
+        /// <summary>
+        /// Reads the Game View's backing RenderTexture via reflection.
+        /// Returns the full composited frame (including ScreenSpaceOverlay UI)
+        /// at the Game View's native resolution, or null on failure.
+        /// </summary>
+        private static Texture2D CaptureGameViewTexture()
+        {
+            try
+            {
+                var assembly = typeof(EditorWindow).Assembly;
+                var gameViewType = assembly.GetType("UnityEditor.GameView");
+                if (gameViewType == null) return null;
+
+                var gameView = EditorWindow.GetWindow(gameViewType, false, null, false);
+                if (gameView == null) return null;
+
+                // PlayModeView (base of GameView) holds m_TargetTexture —
+                // the RenderTexture that Unity's rendering pipeline outputs to.
+                FieldInfo field = null;
+                for (var t = gameViewType; t != null && field == null; t = t.BaseType)
+                    field = t.GetField("m_TargetTexture",
+                        BindingFlags.NonPublic | BindingFlags.Instance);
+
+                var rt = field?.GetValue(gameView) as RenderTexture;
+                if (rt == null || !rt.IsCreated() || rt.width == 0 || rt.height == 0)
+                    return null;
+
+                var prevActive = RenderTexture.active;
+                RenderTexture.active = rt;
+                var tex = new Texture2D(rt.width, rt.height, TextureFormat.RGB24, false);
+                tex.ReadPixels(new Rect(0, 0, rt.width, rt.height), 0, 0);
+                tex.Apply();
+                RenderTexture.active = prevActive;
+
+                return tex;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[MCP] Game View texture capture failed, using fallback: {e.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Renders the main camera (or first available) to a temporary RenderTexture.
+        /// Does not capture ScreenSpaceOverlay canvases.
+        /// </summary>
+        private static Texture2D RenderCameraToTexture(int width, int height)
+        {
+            Camera gameCamera = Camera.main;
+            if (gameCamera == null)
+            {
+                var cameras = Camera.allCameras;
+                if (cameras.Length > 0)
+                    gameCamera = cameras[0];
+            }
+            if (gameCamera == null)
+                throw new InvalidOperationException("No camera found in the scene");
+
+            var rt = new RenderTexture(width, height, 24);
+            var prevRT = gameCamera.targetTexture;
+            gameCamera.targetTexture = rt;
+            gameCamera.Render();
+            gameCamera.targetTexture = prevRT;
+
+            RenderTexture.active = rt;
+            var tex = new Texture2D(width, height, TextureFormat.RGB24, false);
+            tex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+            tex.Apply();
+            RenderTexture.active = null;
+            rt.Release();
+            UnityEngine.Object.DestroyImmediate(rt);
+
+            return tex;
         }
 
         private static object CompareScreenshots(Dictionary<string, object> p)
@@ -230,72 +316,152 @@ namespace UnityMcpPro
             int width = GetIntParam(p, "width", 320);
             int height = GetIntParam(p, "height", 240);
             int quality = GetIntParam(p, "quality", 60);
+            string format = GetStringParam(p, "format", "jpg");
 
             if (!EditorApplication.isPlaying)
                 throw new InvalidOperationException("Play mode is required for frame capture");
 
-            Camera cam = Camera.main;
-            if (cam == null)
-                throw new InvalidOperationException("No main camera found");
+            // Purge sessions older than 60 seconds to prevent memory leaks
+            PurgeOldSessions(60.0);
 
-            var frames = new List<object>();
-            int captured = 0;
-            float nextCapture = (float)EditorApplication.timeSinceStartup;
-
-            EditorApplication.CallbackFunction captureCallback = null;
-            captureCallback = () =>
+            string captureId = Guid.NewGuid().ToString("N").Substring(0, 8);
+            var session = new CaptureSession
             {
-                if (captured >= frameCount || !EditorApplication.isPlaying)
+                targetCount = frameCount,
+                width = width,
+                height = height,
+                quality = quality,
+                format = format,
+                interval = interval,
+                nextCapture = (float)EditorApplication.timeSinceStartup,
+                createdAt = EditorApplication.timeSinceStartup
+            };
+            _captureSessions[captureId] = session;
+
+            EditorApplication.CallbackFunction callback = null;
+            callback = () =>
+            {
+                if (session.complete)
                 {
-                    EditorApplication.update -= captureCallback;
+                    EditorApplication.update -= callback;
                     return;
                 }
 
-                float currentTime = (float)EditorApplication.timeSinceStartup;
-                if (currentTime >= nextCapture)
+                if (!EditorApplication.isPlaying)
                 {
-                    var rt = new RenderTexture(width, height, 24);
-                    var prevRT = cam.targetTexture;
-                    cam.targetTexture = rt;
-                    cam.Render();
-                    cam.targetTexture = prevRT;
+                    session.complete = true;
+                    EditorApplication.update -= callback;
+                    return;
+                }
 
-                    RenderTexture.active = rt;
-                    var tex = new Texture2D(width, height, TextureFormat.RGB24, false);
-                    tex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
-                    tex.Apply();
+                float now = (float)EditorApplication.timeSinceStartup;
+                if (now < session.nextCapture)
+                    return;
+
+                Texture2D tex = CaptureGameViewTexture();
+                if (tex != null)
+                {
+                    session.source = "game_view";
+                }
+                else
+                {
+                    tex = RenderCameraToTexture(width, height);
+                    session.source = "camera_render";
+                }
+
+                // Resize if needed
+                if (tex.width != width || tex.height != height)
+                {
+                    var resizeRt = new RenderTexture(width, height, 0);
+                    Graphics.Blit(tex, resizeRt);
+                    RenderTexture.active = resizeRt;
+                    var resizedTex = new Texture2D(width, height, TextureFormat.RGB24, false);
+                    resizedTex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+                    resizedTex.Apply();
                     RenderTexture.active = null;
-
-                    byte[] jpg = tex.EncodeToJPG(quality);
-
-                    frames.Add(new Dictionary<string, object>
-                    {
-                        { "frame", captured },
-                        { "timestamp", currentTime },
-                        { "image", Convert.ToBase64String(jpg) }
-                    });
-
                     UnityEngine.Object.DestroyImmediate(tex);
-                    rt.Release();
-                    UnityEngine.Object.DestroyImmediate(rt);
+                    resizeRt.Release();
+                    UnityEngine.Object.DestroyImmediate(resizeRt);
+                    tex = resizedTex;
+                }
 
-                    captured++;
-                    nextCapture = currentTime + interval;
+                byte[] imageData = EncodeTexture(tex, format, quality);
+                UnityEngine.Object.DestroyImmediate(tex);
+
+                session.frames.Add(new Dictionary<string, object>
+                {
+                    { "frame", session.frames.Count },
+                    { "timestamp", now },
+                    { "image", Convert.ToBase64String(imageData) },
+                    { "mimeType", GetMimeType(format) }
+                });
+
+                session.nextCapture = now + interval;
+
+                if (session.frames.Count >= session.targetCount)
+                {
+                    session.complete = true;
+                    EditorApplication.update -= callback;
                 }
             };
 
-            EditorApplication.update += captureCallback;
+            EditorApplication.update += callback;
 
-            // Return immediately with metadata; frames are captured async
             return new Dictionary<string, object>
             {
                 { "status", "capturing" },
+                { "capture_id", captureId },
                 { "frameCount", frameCount },
                 { "interval", interval },
                 { "width", width },
                 { "height", height },
-                { "message", $"Capturing {frameCount} frames at {interval}s intervals" }
+                { "format", format },
+                { "message", $"Capturing {frameCount} frames at {interval}s intervals. Use get_captured_frames with capture_id \"{captureId}\" to retrieve results." }
             };
+        }
+
+        private static object GetCapturedFrames(Dictionary<string, object> p)
+        {
+            string captureId = GetStringParam(p, "capture_id");
+            if (string.IsNullOrEmpty(captureId))
+                throw new ArgumentException("capture_id is required");
+
+            if (!_captureSessions.TryGetValue(captureId, out var session))
+                throw new ArgumentException($"No capture session found with id \"{captureId}\"");
+
+            var result = new Dictionary<string, object>
+            {
+                { "capture_id", captureId },
+                { "status", session.complete ? "complete" : "capturing" },
+                { "capturedCount", session.frames.Count },
+                { "targetCount", session.targetCount },
+                { "width", session.width },
+                { "height", session.height },
+                { "format", session.format },
+                { "source", session.source ?? "pending" }
+            };
+
+            if (session.complete)
+            {
+                // Return frames and clean up the session
+                result["frames"] = session.frames;
+                _captureSessions.Remove(captureId);
+            }
+
+            return result;
+        }
+
+        private static void PurgeOldSessions(double maxAgeSeconds)
+        {
+            var stale = new List<string>();
+            double now = EditorApplication.timeSinceStartup;
+            foreach (var kv in _captureSessions)
+            {
+                if (now - kv.Value.createdAt > maxAgeSeconds)
+                    stale.Add(kv.Key);
+            }
+            foreach (var id in stale)
+                _captureSessions.Remove(id);
         }
     }
 }

--- a/Editor/Commands/ScreenshotCommands.cs
+++ b/Editor/Commands/ScreenshotCommands.cs
@@ -8,6 +8,9 @@ namespace UnityMcpPro
 {
     public class ScreenshotCommands : BaseCommand
     {
+        // Only touched from the main thread: WebSocketServer queues inbound
+        // commands onto EditorApplication.update, the same loop the capture
+        // callback runs on. No locking needed as long as that invariant holds.
         private static readonly Dictionary<string, CaptureSession> _captureSessions
             = new Dictionary<string, CaptureSession>();
 
@@ -24,6 +27,7 @@ namespace UnityMcpPro
             public bool complete;
             public string source;
             public double createdAt;
+            public string error;
         }
 
         public static void Register(CommandRouter router)
@@ -173,7 +177,12 @@ namespace UnityMcpPro
                 var gameViewType = assembly.GetType("UnityEditor.GameView");
                 if (gameViewType == null) return null;
 
-                var gameView = EditorWindow.GetWindow(gameViewType, false, null, false);
+                // Probe for an existing Game View before calling GetWindow,
+                // which would otherwise create one and surprise the user.
+                EditorWindow gameView = null;
+                var existing = Resources.FindObjectsOfTypeAll(gameViewType);
+                if (existing != null && existing.Length > 0)
+                    gameView = existing[0] as EditorWindow;
                 if (gameView == null) return null;
 
                 // PlayModeView (base of GameView) holds m_TargetTexture —
@@ -358,50 +367,62 @@ namespace UnityMcpPro
                 if (now < session.nextCapture)
                     return;
 
-                Texture2D tex = CaptureGameViewTexture();
-                if (tex != null)
+                // If the capture body throws (e.g. no camera for the fallback
+                // path) we must mark the session complete and unsubscribe,
+                // otherwise the exception keeps firing every editor tick.
+                try
                 {
-                    session.source = "game_view";
-                }
-                else
-                {
-                    tex = RenderCameraToTexture(width, height);
-                    session.source = "camera_render";
-                }
+                    Texture2D tex = CaptureGameViewTexture();
+                    if (tex != null)
+                    {
+                        session.source = "game_view";
+                    }
+                    else
+                    {
+                        tex = RenderCameraToTexture(width, height);
+                        session.source = "camera_render";
+                    }
 
-                // Resize if needed
-                if (tex.width != width || tex.height != height)
-                {
-                    var resizeRt = new RenderTexture(width, height, 0);
-                    Graphics.Blit(tex, resizeRt);
-                    RenderTexture.active = resizeRt;
-                    var resizedTex = new Texture2D(width, height, TextureFormat.RGB24, false);
-                    resizedTex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
-                    resizedTex.Apply();
-                    RenderTexture.active = null;
+                    if (tex.width != width || tex.height != height)
+                    {
+                        var resizeRt = new RenderTexture(width, height, 0);
+                        Graphics.Blit(tex, resizeRt);
+                        RenderTexture.active = resizeRt;
+                        var resizedTex = new Texture2D(width, height, TextureFormat.RGB24, false);
+                        resizedTex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+                        resizedTex.Apply();
+                        RenderTexture.active = null;
+                        UnityEngine.Object.DestroyImmediate(tex);
+                        resizeRt.Release();
+                        UnityEngine.Object.DestroyImmediate(resizeRt);
+                        tex = resizedTex;
+                    }
+
+                    byte[] imageData = EncodeTexture(tex, format, quality);
                     UnityEngine.Object.DestroyImmediate(tex);
-                    resizeRt.Release();
-                    UnityEngine.Object.DestroyImmediate(resizeRt);
-                    tex = resizedTex;
+
+                    session.frames.Add(new Dictionary<string, object>
+                    {
+                        { "frame", session.frames.Count },
+                        { "timestamp", now },
+                        { "image", Convert.ToBase64String(imageData) },
+                        { "mimeType", GetMimeType(format) }
+                    });
+
+                    session.nextCapture = now + interval;
+
+                    if (session.frames.Count >= session.targetCount)
+                    {
+                        session.complete = true;
+                        EditorApplication.update -= callback;
+                    }
                 }
-
-                byte[] imageData = EncodeTexture(tex, format, quality);
-                UnityEngine.Object.DestroyImmediate(tex);
-
-                session.frames.Add(new Dictionary<string, object>
+                catch (Exception e)
                 {
-                    { "frame", session.frames.Count },
-                    { "timestamp", now },
-                    { "image", Convert.ToBase64String(imageData) },
-                    { "mimeType", GetMimeType(format) }
-                });
-
-                session.nextCapture = now + interval;
-
-                if (session.frames.Count >= session.targetCount)
-                {
+                    session.error = e.Message;
                     session.complete = true;
                     EditorApplication.update -= callback;
+                    Debug.LogError($"[MCP] Frame capture failed: {e.Message}");
                 }
             };
 
@@ -432,32 +453,38 @@ namespace UnityMcpPro
             var result = new Dictionary<string, object>
             {
                 { "capture_id", captureId },
-                { "status", session.complete ? "complete" : "capturing" },
+                { "status", session.error != null ? "error" : (session.complete ? "complete" : "capturing") },
                 { "capturedCount", session.frames.Count },
                 { "targetCount", session.targetCount },
                 { "width", session.width },
                 { "height", session.height },
                 { "format", session.format },
-                { "source", session.source ?? "pending" }
+                { "source", session.source ?? "pending" },
+                // Always expose whatever frames have been captured so far —
+                // callers polling a long-running session can stream results
+                // instead of waiting for completion.
+                { "frames", session.frames }
             };
 
+            if (session.error != null)
+                result["error"] = session.error;
+
             if (session.complete)
-            {
-                // Return frames and clean up the session
-                result["frames"] = session.frames;
                 _captureSessions.Remove(captureId);
-            }
 
             return result;
         }
 
         private static void PurgeOldSessions(double maxAgeSeconds)
         {
+            // Only evict sessions that have already finished — in-flight
+            // captures can legitimately outlive the TTL on long runs
+            // (e.g. frame_count=200, interval=1s).
             var stale = new List<string>();
             double now = EditorApplication.timeSinceStartup;
             foreach (var kv in _captureSessions)
             {
-                if (now - kv.Value.createdAt > maxAgeSeconds)
+                if (kv.Value.complete && now - kv.Value.createdAt > maxAgeSeconds)
                     stale.Add(kv.Key);
             }
             foreach (var id in stale)


### PR DESCRIPTION
## Fix: Capture game screenshots from Game View RenderTexture instead of editor framebuffer

### Problem

`ScreenCapture.CaptureScreenshotAsTexture()` requires end-of-frame timing to work correctly. When called synchronously from the MCP command handler, it reads the **editor's framebuffer** instead of the game view, producing:

- Editor chrome / window decorations in the screenshot
- Tiled artifacts
- Resolution mismatch

### Solution

Replace `ScreenCapture.CaptureScreenshotAsTexture()` with a direct read from the Game View's internal `RenderTexture` (`PlayModeView.m_TargetTexture`) via reflection. This texture contains the fully composited frame, including `ScreenSpaceOverlay` UI, at the Game View's native resolution.

Key changes in `Editor/Commands/ScreenshotCommands.cs`:

- **`CaptureGameViewTexture()`** — new method that reflects into `PlayModeView.m_TargetTexture` to grab the composited game frame. Falls back gracefully if the field is unavailable.
- **`RenderCameraToTexture()`** — extracted the existing camera-render logic into a shared helper, used as a fallback when the Game View RT is not available (e.g. edit mode).
- **`capture_frames` reworked to async two-phase flow:**
  - `capture_frames` starts the session and immediately returns a `capture_id`
  - `get_captured_frames` retrieves results (or progress) by `capture_id`
  - Sessions auto-purge after 60 seconds to prevent memory leaks
- Frame capture now also uses `CaptureGameViewTexture()` with camera fallback, and supports resizing and configurable format.
