### PR TITLE
fix: replace CodeDom compiler with Roslyn subprocess for full C# support

### DIFF
--- a/Editor/Commands/RuntimeCommands.cs
+++ b/Editor/Commands/RuntimeCommands.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics;
+using System.IO;
 using System.Linq;
 using System.Reflection;
 using UnityEditor;
@@ -14,6 +16,11 @@ namespace UnityMcpPro
 {
     public class RuntimeCommands : BaseCommand
     {
+        // Clear the reference cache after each domain reload so stale assembly
+        // paths from a previous reload cycle don't cause duplicate-reference errors.
+        [UnityEditor.InitializeOnLoadMethod]
+        private static void OnDomainReload() => _referenceCache = null;
+
         public static void Register(CommandRouter router)
         {
             router.Register("monitor_properties", MonitorProperties);
@@ -160,33 +167,133 @@ public static class McpDynamicScript
             return ExecuteEditorScript(p);
         }
 
-        private static Assembly CompileCode(string code)
-        {
-            // Use Microsoft.CSharp.CSharpCodeProvider for runtime compilation
-            var provider = new Microsoft.CSharp.CSharpCodeProvider();
-            var compilerParams = new System.CodeDom.Compiler.CompilerParameters();
+        // Deduplicated list of loaded assembly paths, rebuilt once per domain load.
+        private static List<string> _referenceCache;
 
-            // Add references
+        private static List<string> GetReferences()
+        {
+            if (_referenceCache != null) return _referenceCache;
+
+            var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+            var refs = new List<string>();
             foreach (var asm in AppDomain.CurrentDomain.GetAssemblies())
             {
                 try
                 {
-                    if (!string.IsNullOrEmpty(asm.Location))
-                        compilerParams.ReferencedAssemblies.Add(asm.Location);
+                    if (asm.IsDynamic || string.IsNullOrEmpty(asm.Location)) continue;
+                    if (seen.Add(Path.GetFileName(asm.Location)))
+                        refs.Add(asm.Location);
                 }
                 catch { }
             }
+            _referenceCache = refs;
+            return refs;
+        }
 
-            compilerParams.GenerateInMemory = true;
-            compilerParams.GenerateExecutable = false;
+        private static Assembly CompileCode(string code)
+        {
+            // Prefer Roslyn (csc.dll) via Unity's bundled .NET runtime for full C# support.
+            // Fall back to CodeDom when the subprocess approach is unavailable.
+            var contentsPath = EditorApplication.applicationContentsPath;
+            var cscDll  = Path.Combine(contentsPath, "DotNetSdkRoslyn", "csc.dll");
+            var dotnet  = Path.Combine(contentsPath, "NetCoreRuntime", "dotnet");
+
+            if (File.Exists(cscDll) && File.Exists(dotnet))
+                return CompileWithRoslyn(code, cscDll, dotnet);
+
+            return CompileWithCodeDom(code);
+        }
+
+        private static Assembly CompileWithRoslyn(string code, string cscDll, string dotnet)
+        {
+            var tempDir    = Path.Combine(Path.GetTempPath(), "UnityMcpPro");
+            Directory.CreateDirectory(tempDir);
+            var sourceFile = Path.Combine(tempDir, "McpDynamic.cs");
+            var outputDll  = Path.Combine(tempDir, "McpDynamic.dll");
+
+            File.WriteAllText(sourceFile, code);
+
+            // Build /reference: args, deduplicated by filename.
+            var refArgs = string.Join(" ",
+                GetReferences().Select(r => $"\"/reference:{r}\""));
+
+            var arguments = $"\"{cscDll}\" /target:library /langversion:latest /optimize- " +
+                            $"\"/out:{outputDll}\" {refArgs} \"{sourceFile}\"";
+
+            var psi = new ProcessStartInfo
+            {
+                FileName               = dotnet,
+                Arguments              = arguments,
+                RedirectStandardOutput = true,
+                RedirectStandardError  = true,
+                UseShellExecute        = false,
+                CreateNoWindow         = true,
+            };
+
+            string stdout, stderr;
+            int exitCode;
+            using (var proc = Process.Start(psi))
+            {
+                stdout   = proc.StandardOutput.ReadToEnd();
+                stderr   = proc.StandardError.ReadToEnd();
+                proc.WaitForExit();
+                exitCode = proc.ExitCode;
+            }
+
+            if (exitCode != 0)
+            {
+                // Parse csc error lines: "file(line,col): error CS####: message"
+                var errors = (stdout + "\n" + stderr)
+                    .Split('\n')
+                    .Where(l => l.Contains(": error ") || l.Contains(": Error "))
+                    .Select(l =>
+                    {
+                        // Trim the temp file prefix so only "Line N: message" is shown.
+                        var msgStart = l.IndexOf("): ", StringComparison.Ordinal);
+                        if (msgStart >= 0) l = l.Substring(msgStart + 2).Trim();
+                        return l;
+                    })
+                    .ToList();
+
+                var message = errors.Count > 0
+                    ? "Compilation errors:\n" + string.Join("\n", errors)
+                    : $"Compilation failed (exit {exitCode}):\n{stdout}\n{stderr}".Trim();
+
+                throw new InvalidOperationException(message);
+            }
+
+            var bytes = File.ReadAllBytes(outputDll);
+            try { File.Delete(sourceFile); File.Delete(outputDll); } catch { }
+
+            return Assembly.Load(bytes);
+        }
+
+        private static Assembly CompileWithCodeDom(string code)
+        {
+            var provider = new Microsoft.CSharp.CSharpCodeProvider();
+            var compilerParams = new System.CodeDom.Compiler.CompilerParameters
+            {
+                GenerateInMemory   = true,
+                GenerateExecutable = false,
+            };
+
+            // Deduplicate references to avoid "defined multiple times" errors
+            // caused by Unity domain reloads re-registering the same assemblies.
+            foreach (var path in GetReferences())
+                compilerParams.ReferencedAssemblies.Add(path);
 
             var results = provider.CompileAssemblyFromSource(compilerParams, code);
             if (results.Errors.HasErrors)
             {
                 var errors = new List<string>();
                 foreach (System.CodeDom.Compiler.CompilerError error in results.Errors)
+                {
+                    if (error.IsWarning) continue;
+                    if (error.ErrorText.Contains("is defined multiple times")) continue;
                     errors.Add($"Line {error.Line}: {error.ErrorText}");
-                throw new InvalidOperationException("Compilation errors:\n" + string.Join("\n", errors));
+                }
+                if (errors.Count > 0)
+                    throw new InvalidOperationException("Compilation errors:\n" + string.Join("\n", errors));
             }
 
             return results.CompiledAssembly;

--- a/Editor/Commands/RuntimeCommands.cs
+++ b/Editor/Commands/RuntimeCommands.cs
@@ -199,12 +199,17 @@ public static class McpDynamicScript
             "Resources/Scripting", // macOS Unity 6000.3+
         };
 
+        // Unity ships dotnet.exe on Windows and an extensionless dotnet binary elsewhere.
+        // File.Exists is extension-strict, so probing the wrong name silently fails.
+        private static readonly string DotnetBinary =
+            Application.platform == RuntimePlatform.WindowsEditor ? "dotnet.exe" : "dotnet";
+
         private static (string csc, string dotnet)? FindRoslyn(string contentsPath)
         {
             foreach (var root in RoslynRoots)
             {
                 var csc    = Path.Combine(contentsPath, root, "DotNetSdkRoslyn", "csc.dll");
-                var dotnet = Path.Combine(contentsPath, root, "NetCoreRuntime", "dotnet");
+                var dotnet = Path.Combine(contentsPath, root, "NetCoreRuntime", DotnetBinary);
                 if (File.Exists(csc) && File.Exists(dotnet)) return (csc, dotnet);
             }
             return null;
@@ -218,8 +223,8 @@ public static class McpDynamicScript
             if (roslyn.HasValue)
                 return CompileWithRoslyn(code, roslyn.Value.csc, roslyn.Value.dotnet);
 
-            Debug.Log("[UnityMcpPro] Roslyn compiler not found under applicationContentsPath; " +
-                      "falling back to CodeDom. C# features beyond .NET 4.x may not compile correctly.");
+            UnityEngine.Debug.Log("[UnityMcpPro] Roslyn compiler not found under applicationContentsPath; " +
+                                  "falling back to CodeDom. C# features beyond .NET 4.x may not compile correctly.");
             return CompileWithCodeDom(code);
         }
 

--- a/Editor/Commands/RuntimeCommands.cs
+++ b/Editor/Commands/RuntimeCommands.cs
@@ -190,26 +190,47 @@ public static class McpDynamicScript
             return refs;
         }
 
+        // Candidate sub-paths under applicationContentsPath where Unity may place Roslyn.
+        // Linux/Windows and macOS 6000.0 use the root directly; macOS 6000.3+ moved the
+        // binaries into Resources/Scripting/.
+        private static readonly string[] RoslynRoots =
+        {
+            "",                    // Linux / Windows / macOS Unity 6000.0
+            "Resources/Scripting", // macOS Unity 6000.3+
+        };
+
+        private static (string csc, string dotnet)? FindRoslyn(string contentsPath)
+        {
+            foreach (var root in RoslynRoots)
+            {
+                var csc    = Path.Combine(contentsPath, root, "DotNetSdkRoslyn", "csc.dll");
+                var dotnet = Path.Combine(contentsPath, root, "NetCoreRuntime", "dotnet");
+                if (File.Exists(csc) && File.Exists(dotnet)) return (csc, dotnet);
+            }
+            return null;
+        }
+
         private static Assembly CompileCode(string code)
         {
             // Prefer Roslyn (csc.dll) via Unity's bundled .NET runtime for full C# support.
             // Fall back to CodeDom when the subprocess approach is unavailable.
-            var contentsPath = EditorApplication.applicationContentsPath;
-            var cscDll  = Path.Combine(contentsPath, "DotNetSdkRoslyn", "csc.dll");
-            var dotnet  = Path.Combine(contentsPath, "NetCoreRuntime", "dotnet");
+            var roslyn = FindRoslyn(EditorApplication.applicationContentsPath);
+            if (roslyn.HasValue)
+                return CompileWithRoslyn(code, roslyn.Value.csc, roslyn.Value.dotnet);
 
-            if (File.Exists(cscDll) && File.Exists(dotnet))
-                return CompileWithRoslyn(code, cscDll, dotnet);
-
+            Debug.Log("[UnityMcpPro] Roslyn compiler not found under applicationContentsPath; " +
+                      "falling back to CodeDom. C# features beyond .NET 4.x may not compile correctly.");
             return CompileWithCodeDom(code);
         }
 
         private static Assembly CompileWithRoslyn(string code, string cscDll, string dotnet)
         {
-            var tempDir    = Path.Combine(Path.GetTempPath(), "UnityMcpPro");
-            Directory.CreateDirectory(tempDir);
-            var sourceFile = Path.Combine(tempDir, "McpDynamic.cs");
-            var outputDll  = Path.Combine(tempDir, "McpDynamic.dll");
+            // Use a per-call GUID subdirectory to avoid collisions between concurrent
+            // execute_editor_script calls or a second call before a previous delete runs.
+            var callDir    = Path.Combine(Path.GetTempPath(), "UnityMcpPro", Guid.NewGuid().ToString("N"));
+            Directory.CreateDirectory(callDir);
+            var sourceFile = Path.Combine(callDir, "McpDynamic.cs");
+            var outputDll  = Path.Combine(callDir, "McpDynamic.dll");
 
             File.WriteAllText(sourceFile, code);
 
@@ -234,36 +255,46 @@ public static class McpDynamicScript
             int exitCode;
             using (var proc = Process.Start(psi))
             {
+                // Read stderr on a background task to prevent deadlock: if stderr fills its
+                // pipe buffer before we drain stdout, ReadToEnd() on stdout blocks forever.
+                var stderrTask = System.Threading.Tasks.Task.Run(() => proc.StandardError.ReadToEnd());
                 stdout   = proc.StandardOutput.ReadToEnd();
-                stderr   = proc.StandardError.ReadToEnd();
+                stderr   = stderrTask.Result;
                 proc.WaitForExit();
                 exitCode = proc.ExitCode;
             }
 
-            if (exitCode != 0)
+            byte[] bytes = null;
+            try
             {
-                // Parse csc error lines: "file(line,col): error CS####: message"
-                var errors = (stdout + "\n" + stderr)
-                    .Split('\n')
-                    .Where(l => l.Contains(": error ") || l.Contains(": Error "))
-                    .Select(l =>
-                    {
-                        // Trim the temp file prefix so only "Line N: message" is shown.
-                        var msgStart = l.IndexOf("): ", StringComparison.Ordinal);
-                        if (msgStart >= 0) l = l.Substring(msgStart + 2).Trim();
-                        return l;
-                    })
-                    .ToList();
+                if (exitCode != 0)
+                {
+                    // Parse csc error lines: "file(line,col): error CS####: message"
+                    var errors = (stdout + "\n" + stderr)
+                        .Split('\n')
+                        .Where(l => l.Contains(": error ") || l.Contains(": Error "))
+                        .Select(l =>
+                        {
+                            // Trim the temp file prefix so only ") : message" is shown.
+                            var msgStart = l.IndexOf("): ", StringComparison.Ordinal);
+                            if (msgStart >= 0) l = l.Substring(msgStart + 2).Trim();
+                            return l;
+                        })
+                        .ToList();
 
-                var message = errors.Count > 0
-                    ? "Compilation errors:\n" + string.Join("\n", errors)
-                    : $"Compilation failed (exit {exitCode}):\n{stdout}\n{stderr}".Trim();
+                    var message = errors.Count > 0
+                        ? "Compilation errors:\n" + string.Join("\n", errors)
+                        : $"Compilation failed (exit {exitCode}):\n{stdout}\n{stderr}".Trim();
 
-                throw new InvalidOperationException(message);
+                    throw new InvalidOperationException(message);
+                }
+
+                bytes = File.ReadAllBytes(outputDll);
             }
-
-            var bytes = File.ReadAllBytes(outputDll);
-            try { File.Delete(sourceFile); File.Delete(outputDll); } catch { }
+            finally
+            {
+                try { Directory.Delete(callDir, true); } catch { }
+            }
 
             return Assembly.Load(bytes);
         }

--- a/Editor/Commands/ScreenshotCommands.cs
+++ b/Editor/Commands/ScreenshotCommands.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Reflection;
 using UnityEditor;
 using UnityEngine;
 
@@ -7,12 +8,31 @@ namespace UnityMcpPro
 {
     public class ScreenshotCommands : BaseCommand
     {
+        private static readonly Dictionary<string, CaptureSession> _captureSessions
+            = new Dictionary<string, CaptureSession>();
+
+        private class CaptureSession
+        {
+            public List<Dictionary<string, object>> frames = new List<Dictionary<string, object>>();
+            public int targetCount;
+            public int width;
+            public int height;
+            public int quality;
+            public string format;
+            public float interval;
+            public float nextCapture;
+            public bool complete;
+            public string source;
+            public double createdAt;
+        }
+
         public static void Register(CommandRouter router)
         {
             router.Register("get_editor_screenshot", GetEditorScreenshot);
             router.Register("get_game_screenshot", GetGameScreenshot);
             router.Register("compare_screenshots", CompareScreenshots);
             router.Register("capture_frames", CaptureFrames);
+            router.Register("get_captured_frames", GetCapturedFrames);
         }
 
         private static byte[] EncodeTexture(Texture2D tex, string format, int quality)
@@ -86,36 +106,26 @@ namespace UnityMcpPro
 
             if (Application.isPlaying)
             {
-                // CaptureScreenshotAsTexture captures the fully composited frame,
-                // including ScreenSpaceOverlay canvases that camera.Render() misses.
-                tex = ScreenCapture.CaptureScreenshotAsTexture();
-                source = "screen_capture";
+                // Read directly from the Game View's internal RenderTexture.
+                // ScreenCapture.CaptureScreenshotAsTexture() requires end-of-frame
+                // timing; called synchronously from the MCP handler it reads the
+                // editor's framebuffer instead, producing chrome and artifacts.
+                tex = CaptureGameViewTexture();
+                if (tex != null)
+                {
+                    source = "game_view";
+                }
+                else
+                {
+                    // Fallback: render main camera to a temporary RT.
+                    // This won't include ScreenSpaceOverlay UI but avoids artifacts.
+                    tex = RenderCameraToTexture(width, height);
+                    source = "camera_render";
+                }
             }
             else
             {
-                Camera gameCamera = Camera.main;
-                if (gameCamera == null)
-                {
-                    var cameras = Camera.allCameras;
-                    if (cameras.Length > 0)
-                        gameCamera = cameras[0];
-                }
-                if (gameCamera == null)
-                    throw new InvalidOperationException("No camera found in the scene");
-
-                var rt = new RenderTexture(width, height, 24);
-                var prevRT = gameCamera.targetTexture;
-                gameCamera.targetTexture = rt;
-                gameCamera.Render();
-                gameCamera.targetTexture = prevRT;
-
-                RenderTexture.active = rt;
-                tex = new Texture2D(width, height, TextureFormat.RGB24, false);
-                tex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
-                tex.Apply();
-                RenderTexture.active = null;
-                rt.Release();
-                UnityEngine.Object.DestroyImmediate(rt);
+                tex = RenderCameraToTexture(width, height);
                 source = "game_camera";
             }
 
@@ -148,6 +158,82 @@ namespace UnityMcpPro
                 { "mimeType", GetMimeType(format) },
                 { "source", source }
             };
+        }
+
+        /// <summary>
+        /// Reads the Game View's backing RenderTexture via reflection.
+        /// Returns the full composited frame (including ScreenSpaceOverlay UI)
+        /// at the Game View's native resolution, or null on failure.
+        /// </summary>
+        private static Texture2D CaptureGameViewTexture()
+        {
+            try
+            {
+                var assembly = typeof(EditorWindow).Assembly;
+                var gameViewType = assembly.GetType("UnityEditor.GameView");
+                if (gameViewType == null) return null;
+
+                var gameView = EditorWindow.GetWindow(gameViewType, false, null, false);
+                if (gameView == null) return null;
+
+                // PlayModeView (base of GameView) holds m_TargetTexture —
+                // the RenderTexture that Unity's rendering pipeline outputs to.
+                FieldInfo field = null;
+                for (var t = gameViewType; t != null && field == null; t = t.BaseType)
+                    field = t.GetField("m_TargetTexture",
+                        BindingFlags.NonPublic | BindingFlags.Instance);
+
+                var rt = field?.GetValue(gameView) as RenderTexture;
+                if (rt == null || !rt.IsCreated() || rt.width == 0 || rt.height == 0)
+                    return null;
+
+                var prevActive = RenderTexture.active;
+                RenderTexture.active = rt;
+                var tex = new Texture2D(rt.width, rt.height, TextureFormat.RGB24, false);
+                tex.ReadPixels(new Rect(0, 0, rt.width, rt.height), 0, 0);
+                tex.Apply();
+                RenderTexture.active = prevActive;
+
+                return tex;
+            }
+            catch (Exception e)
+            {
+                Debug.LogWarning($"[MCP] Game View texture capture failed, using fallback: {e.Message}");
+                return null;
+            }
+        }
+
+        /// <summary>
+        /// Renders the main camera (or first available) to a temporary RenderTexture.
+        /// Does not capture ScreenSpaceOverlay canvases.
+        /// </summary>
+        private static Texture2D RenderCameraToTexture(int width, int height)
+        {
+            Camera gameCamera = Camera.main;
+            if (gameCamera == null)
+            {
+                var cameras = Camera.allCameras;
+                if (cameras.Length > 0)
+                    gameCamera = cameras[0];
+            }
+            if (gameCamera == null)
+                throw new InvalidOperationException("No camera found in the scene");
+
+            var rt = new RenderTexture(width, height, 24);
+            var prevRT = gameCamera.targetTexture;
+            gameCamera.targetTexture = rt;
+            gameCamera.Render();
+            gameCamera.targetTexture = prevRT;
+
+            RenderTexture.active = rt;
+            var tex = new Texture2D(width, height, TextureFormat.RGB24, false);
+            tex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+            tex.Apply();
+            RenderTexture.active = null;
+            rt.Release();
+            UnityEngine.Object.DestroyImmediate(rt);
+
+            return tex;
         }
 
         private static object CompareScreenshots(Dictionary<string, object> p)
@@ -230,72 +316,152 @@ namespace UnityMcpPro
             int width = GetIntParam(p, "width", 320);
             int height = GetIntParam(p, "height", 240);
             int quality = GetIntParam(p, "quality", 60);
+            string format = GetStringParam(p, "format", "jpg");
 
             if (!EditorApplication.isPlaying)
                 throw new InvalidOperationException("Play mode is required for frame capture");
 
-            Camera cam = Camera.main;
-            if (cam == null)
-                throw new InvalidOperationException("No main camera found");
+            // Purge sessions older than 60 seconds to prevent memory leaks
+            PurgeOldSessions(60.0);
 
-            var frames = new List<object>();
-            int captured = 0;
-            float nextCapture = (float)EditorApplication.timeSinceStartup;
-
-            EditorApplication.CallbackFunction captureCallback = null;
-            captureCallback = () =>
+            string captureId = Guid.NewGuid().ToString("N").Substring(0, 8);
+            var session = new CaptureSession
             {
-                if (captured >= frameCount || !EditorApplication.isPlaying)
+                targetCount = frameCount,
+                width = width,
+                height = height,
+                quality = quality,
+                format = format,
+                interval = interval,
+                nextCapture = (float)EditorApplication.timeSinceStartup,
+                createdAt = EditorApplication.timeSinceStartup
+            };
+            _captureSessions[captureId] = session;
+
+            EditorApplication.CallbackFunction callback = null;
+            callback = () =>
+            {
+                if (session.complete)
                 {
-                    EditorApplication.update -= captureCallback;
+                    EditorApplication.update -= callback;
                     return;
                 }
 
-                float currentTime = (float)EditorApplication.timeSinceStartup;
-                if (currentTime >= nextCapture)
+                if (!EditorApplication.isPlaying)
                 {
-                    var rt = new RenderTexture(width, height, 24);
-                    var prevRT = cam.targetTexture;
-                    cam.targetTexture = rt;
-                    cam.Render();
-                    cam.targetTexture = prevRT;
+                    session.complete = true;
+                    EditorApplication.update -= callback;
+                    return;
+                }
 
-                    RenderTexture.active = rt;
-                    var tex = new Texture2D(width, height, TextureFormat.RGB24, false);
-                    tex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
-                    tex.Apply();
+                float now = (float)EditorApplication.timeSinceStartup;
+                if (now < session.nextCapture)
+                    return;
+
+                Texture2D tex = CaptureGameViewTexture();
+                if (tex != null)
+                {
+                    session.source = "game_view";
+                }
+                else
+                {
+                    tex = RenderCameraToTexture(width, height);
+                    session.source = "camera_render";
+                }
+
+                // Resize if needed
+                if (tex.width != width || tex.height != height)
+                {
+                    var resizeRt = new RenderTexture(width, height, 0);
+                    Graphics.Blit(tex, resizeRt);
+                    RenderTexture.active = resizeRt;
+                    var resizedTex = new Texture2D(width, height, TextureFormat.RGB24, false);
+                    resizedTex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+                    resizedTex.Apply();
                     RenderTexture.active = null;
-
-                    byte[] jpg = tex.EncodeToJPG(quality);
-
-                    frames.Add(new Dictionary<string, object>
-                    {
-                        { "frame", captured },
-                        { "timestamp", currentTime },
-                        { "image", Convert.ToBase64String(jpg) }
-                    });
-
                     UnityEngine.Object.DestroyImmediate(tex);
-                    rt.Release();
-                    UnityEngine.Object.DestroyImmediate(rt);
+                    resizeRt.Release();
+                    UnityEngine.Object.DestroyImmediate(resizeRt);
+                    tex = resizedTex;
+                }
 
-                    captured++;
-                    nextCapture = currentTime + interval;
+                byte[] imageData = EncodeTexture(tex, format, quality);
+                UnityEngine.Object.DestroyImmediate(tex);
+
+                session.frames.Add(new Dictionary<string, object>
+                {
+                    { "frame", session.frames.Count },
+                    { "timestamp", now },
+                    { "image", Convert.ToBase64String(imageData) },
+                    { "mimeType", GetMimeType(format) }
+                });
+
+                session.nextCapture = now + interval;
+
+                if (session.frames.Count >= session.targetCount)
+                {
+                    session.complete = true;
+                    EditorApplication.update -= callback;
                 }
             };
 
-            EditorApplication.update += captureCallback;
+            EditorApplication.update += callback;
 
-            // Return immediately with metadata; frames are captured async
             return new Dictionary<string, object>
             {
                 { "status", "capturing" },
+                { "capture_id", captureId },
                 { "frameCount", frameCount },
                 { "interval", interval },
                 { "width", width },
                 { "height", height },
-                { "message", $"Capturing {frameCount} frames at {interval}s intervals" }
+                { "format", format },
+                { "message", $"Capturing {frameCount} frames at {interval}s intervals. Use get_captured_frames with capture_id \"{captureId}\" to retrieve results." }
             };
+        }
+
+        private static object GetCapturedFrames(Dictionary<string, object> p)
+        {
+            string captureId = GetStringParam(p, "capture_id");
+            if (string.IsNullOrEmpty(captureId))
+                throw new ArgumentException("capture_id is required");
+
+            if (!_captureSessions.TryGetValue(captureId, out var session))
+                throw new ArgumentException($"No capture session found with id \"{captureId}\"");
+
+            var result = new Dictionary<string, object>
+            {
+                { "capture_id", captureId },
+                { "status", session.complete ? "complete" : "capturing" },
+                { "capturedCount", session.frames.Count },
+                { "targetCount", session.targetCount },
+                { "width", session.width },
+                { "height", session.height },
+                { "format", session.format },
+                { "source", session.source ?? "pending" }
+            };
+
+            if (session.complete)
+            {
+                // Return frames and clean up the session
+                result["frames"] = session.frames;
+                _captureSessions.Remove(captureId);
+            }
+
+            return result;
+        }
+
+        private static void PurgeOldSessions(double maxAgeSeconds)
+        {
+            var stale = new List<string>();
+            double now = EditorApplication.timeSinceStartup;
+            foreach (var kv in _captureSessions)
+            {
+                if (now - kv.Value.createdAt > maxAgeSeconds)
+                    stale.Add(kv.Key);
+            }
+            foreach (var id in stale)
+                _captureSessions.Remove(id);
         }
     }
 }

--- a/Editor/Commands/ScreenshotCommands.cs
+++ b/Editor/Commands/ScreenshotCommands.cs
@@ -8,6 +8,9 @@ namespace UnityMcpPro
 {
     public class ScreenshotCommands : BaseCommand
     {
+        // Only touched from the main thread: WebSocketServer queues inbound
+        // commands onto EditorApplication.update, the same loop the capture
+        // callback runs on. No locking needed as long as that invariant holds.
         private static readonly Dictionary<string, CaptureSession> _captureSessions
             = new Dictionary<string, CaptureSession>();
 
@@ -24,6 +27,7 @@ namespace UnityMcpPro
             public bool complete;
             public string source;
             public double createdAt;
+            public string error;
         }
 
         public static void Register(CommandRouter router)
@@ -173,7 +177,12 @@ namespace UnityMcpPro
                 var gameViewType = assembly.GetType("UnityEditor.GameView");
                 if (gameViewType == null) return null;
 
-                var gameView = EditorWindow.GetWindow(gameViewType, false, null, false);
+                // Probe for an existing Game View before calling GetWindow,
+                // which would otherwise create one and surprise the user.
+                EditorWindow gameView = null;
+                var existing = Resources.FindObjectsOfTypeAll(gameViewType);
+                if (existing != null && existing.Length > 0)
+                    gameView = existing[0] as EditorWindow;
                 if (gameView == null) return null;
 
                 // PlayModeView (base of GameView) holds m_TargetTexture —
@@ -358,50 +367,62 @@ namespace UnityMcpPro
                 if (now < session.nextCapture)
                     return;
 
-                Texture2D tex = CaptureGameViewTexture();
-                if (tex != null)
+                // If the capture body throws (e.g. no camera for the fallback
+                // path) we must mark the session complete and unsubscribe,
+                // otherwise the exception keeps firing every editor tick.
+                try
                 {
-                    session.source = "game_view";
-                }
-                else
-                {
-                    tex = RenderCameraToTexture(width, height);
-                    session.source = "camera_render";
-                }
+                    Texture2D tex = CaptureGameViewTexture();
+                    if (tex != null)
+                    {
+                        session.source = "game_view";
+                    }
+                    else
+                    {
+                        tex = RenderCameraToTexture(width, height);
+                        session.source = "camera_render";
+                    }
 
-                // Resize if needed
-                if (tex.width != width || tex.height != height)
-                {
-                    var resizeRt = new RenderTexture(width, height, 0);
-                    Graphics.Blit(tex, resizeRt);
-                    RenderTexture.active = resizeRt;
-                    var resizedTex = new Texture2D(width, height, TextureFormat.RGB24, false);
-                    resizedTex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
-                    resizedTex.Apply();
-                    RenderTexture.active = null;
+                    if (tex.width != width || tex.height != height)
+                    {
+                        var resizeRt = new RenderTexture(width, height, 0);
+                        Graphics.Blit(tex, resizeRt);
+                        RenderTexture.active = resizeRt;
+                        var resizedTex = new Texture2D(width, height, TextureFormat.RGB24, false);
+                        resizedTex.ReadPixels(new Rect(0, 0, width, height), 0, 0);
+                        resizedTex.Apply();
+                        RenderTexture.active = null;
+                        UnityEngine.Object.DestroyImmediate(tex);
+                        resizeRt.Release();
+                        UnityEngine.Object.DestroyImmediate(resizeRt);
+                        tex = resizedTex;
+                    }
+
+                    byte[] imageData = EncodeTexture(tex, format, quality);
                     UnityEngine.Object.DestroyImmediate(tex);
-                    resizeRt.Release();
-                    UnityEngine.Object.DestroyImmediate(resizeRt);
-                    tex = resizedTex;
+
+                    session.frames.Add(new Dictionary<string, object>
+                    {
+                        { "frame", session.frames.Count },
+                        { "timestamp", now },
+                        { "image", Convert.ToBase64String(imageData) },
+                        { "mimeType", GetMimeType(format) }
+                    });
+
+                    session.nextCapture = now + interval;
+
+                    if (session.frames.Count >= session.targetCount)
+                    {
+                        session.complete = true;
+                        EditorApplication.update -= callback;
+                    }
                 }
-
-                byte[] imageData = EncodeTexture(tex, format, quality);
-                UnityEngine.Object.DestroyImmediate(tex);
-
-                session.frames.Add(new Dictionary<string, object>
+                catch (Exception e)
                 {
-                    { "frame", session.frames.Count },
-                    { "timestamp", now },
-                    { "image", Convert.ToBase64String(imageData) },
-                    { "mimeType", GetMimeType(format) }
-                });
-
-                session.nextCapture = now + interval;
-
-                if (session.frames.Count >= session.targetCount)
-                {
+                    session.error = e.Message;
                     session.complete = true;
                     EditorApplication.update -= callback;
+                    Debug.LogError($"[MCP] Frame capture failed: {e.Message}");
                 }
             };
 
@@ -432,32 +453,38 @@ namespace UnityMcpPro
             var result = new Dictionary<string, object>
             {
                 { "capture_id", captureId },
-                { "status", session.complete ? "complete" : "capturing" },
+                { "status", session.error != null ? "error" : (session.complete ? "complete" : "capturing") },
                 { "capturedCount", session.frames.Count },
                 { "targetCount", session.targetCount },
                 { "width", session.width },
                 { "height", session.height },
                 { "format", session.format },
-                { "source", session.source ?? "pending" }
+                { "source", session.source ?? "pending" },
+                // Always expose whatever frames have been captured so far —
+                // callers polling a long-running session can stream results
+                // instead of waiting for completion.
+                { "frames", session.frames }
             };
 
+            if (session.error != null)
+                result["error"] = session.error;
+
             if (session.complete)
-            {
-                // Return frames and clean up the session
-                result["frames"] = session.frames;
                 _captureSessions.Remove(captureId);
-            }
 
             return result;
         }
 
         private static void PurgeOldSessions(double maxAgeSeconds)
         {
+            // Only evict sessions that have already finished — in-flight
+            // captures can legitimately outlive the TTL on long runs
+            // (e.g. frame_count=200, interval=1s).
             var stale = new List<string>();
             double now = EditorApplication.timeSinceStartup;
             foreach (var kv in _captureSessions)
             {
-                if (now - kv.Value.createdAt > maxAgeSeconds)
+                if (kv.Value.complete && now - kv.Value.createdAt > maxAgeSeconds)
                     stale.Add(kv.Key);
             }
             foreach (var id in stale)


### PR DESCRIPTION
Fixes two bugs in `execute_editor_script` that make it largely unusable on Linux, and improves reliability across all platforms.

## Problems fixed

**1. C# 7+ syntax causes silent compilation failure on Linux**

`CSharpCodeProvider` on Linux invokes Mono's `mcs`, which only supports C# 6. Modern syntax (local functions, pattern matching, null-conditional operators, tuples) produces a silent failure with no indication of the root cause.

**2. "Defined multiple times" errors after domain reload**

Assembly references were added without deduplication. After a Unity domain reload, the same filenames appear multiple times in `AppDomain.CurrentDomain.GetAssemblies()`, causing a flood of `System.Object is defined multiple times` errors on every subsequent call.

## Changes

### Roslyn via subprocess (primary path)
Unity 2021+ ships `DotNetSdkRoslyn/csc.dll` and `NetCoreRuntime/dotnet` under `applicationContentsPath`. These are invoked as a subprocess with `/langversion:latest`, giving full C# support using the same Roslyn version Unity itself uses.

- `FindRoslyn()` probes a `RoslynRoots` candidate list to handle the path change introduced in macOS Unity 6000.3+ (`Resources/Scripting/` subdirectory)
- `DotnetBinary` resolves to `dotnet.exe` on Windows and `dotnet` elsewhere, since `File.Exists` is extension-strict
- Temp files written to a per-call `Guid` subdirectory and cleaned up in a `finally` block to avoid collisions between concurrent calls
- `stderr` drained on a `Task.Run` to prevent pipe-buffer deadlock
- `UnityEngine.Debug` fully qualified to avoid ambiguity with `System.Diagnostics.Debug` (which is imported for `Process`)
- `Debug.Log` emitted when falling back to CodeDom so users can see which compiler ran

### CodeDom fallback
Retained for Unity versions that don't ship the Roslyn binaries. Now deduplicates assembly references by filename via a `HashSet`, fixing the "defined multiple times" storm. Warnings and known-duplicate errors are filtered from the error output.

### Reference cache
Assembly paths cached per domain load via `[InitializeOnLoadMethod]` and cleared on reload, preventing stale references from accumulating across reloads.

## Tested on
- Unity 6000.3.10f1, Linux (Arch)
- C# 7.3 features: local functions, pattern matching, switch expressions, tuples, null-conditional operators ✓