### PR TITLE
Fix two failing EditMode tests (LogAssert + int truncation)

### DIFF
--- a/Editor/Tests/CommandRouterTests.cs
+++ b/Editor/Tests/CommandRouterTests.cs
@@ -1,6 +1,9 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
 
 namespace UnityMcpPro.Tests
 {
@@ -90,6 +93,10 @@ namespace UnityMcpPro.Tests
         public void Dispatch_HandlerThrows_SendsErrorResponse()
         {
             _router.Register("boom", p => throw new InvalidOperationException("kaboom"));
+
+            // Dispatch logs the caught handler exception via Debug.LogError; Unity's Test Runner
+            // fails any test that emits an unexpected error log, so declare it as expected.
+            LogAssert.Expect(LogType.Error, new Regex(@"\[MCP\] Command error \(boom\): kaboom"));
 
             string response = null;
             var request = new JsonRpcRequest

--- a/Editor/Utils/TypeParser.cs
+++ b/Editor/Utils/TypeParser.cs
@@ -72,7 +72,7 @@ namespace UnityMcpPro
             if (targetType == typeof(Vector4)) return ParseVector4(strVal);
             if (targetType == typeof(Color)) return ParseColor(strVal);
             if (targetType == typeof(Quaternion)) return Quaternion.Euler(ParseVector3(strVal));
-            if (targetType == typeof(int)) return Convert.ToInt32(value);
+            if (targetType == typeof(int)) return (int)Convert.ToDouble(value); // truncate toward zero
             if (targetType == typeof(float)) return Convert.ToSingle(value);
             if (targetType == typeof(double)) return Convert.ToDouble(value);
             if (targetType == typeof(bool)) return Convert.ToBoolean(value);


### PR DESCRIPTION
Running the EditMode suite against `v1.4.0` / current `master` shows **2 failing tests** out of 63. Both are self-contained in the plugin's own test assembly. This PR makes the suite green again (63/63).

## 1. `CommandRouterTests.Dispatch_HandlerThrows_SendsErrorResponse` — test bug

The runtime behavior is already correct: `CommandRouter.Dispatch` catches the handler exception, logs it via `Debug.LogError`, and returns the JSON-RPC `-32000` error response. All three assertions on the response pass.

The test fails only because **Unity's Test Runner fails any test that emits an unexpected `Debug.LogError`** unless it's declared with `LogAssert.Expect`:

```
Unhandled log message: '[Error] [MCP] Command error (boom): kaboom ...'. Use UnityEngine.TestTools.LogAssert.Expect
```

Fix: declare the expected error log. **No runtime change.**

## 2. `TypeParser.ConvertValue(value, typeof(int))` — rounding mismatch

```
ConvertValue(3.7, typeof(int))  →  Expected: 3   But was: 4
```

`Convert.ToInt32(double)` uses banker's rounding (round-half-to-even), so `3.7` becomes `4`, while `ConvertValue_ToInt` expects truncation to `3`. Switched to `(int)Convert.ToDouble(value)` to truncate toward zero, matching the test's intent and the usual "cast a number to int" expectation.

> Note: this one is a genuine semantics choice (truncate vs round). I went with truncation to satisfy the existing test — happy to flip it to update the test instead if you'd prefer to keep rounding behavior.

## Verification

Both changes verified locally: **63/63 EditMode tests pass, 0 failures.**